### PR TITLE
fix(dependencies): Bumped daily flutter and permission handler versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,13 +11,13 @@ dependencies:
   openai_dart: ^0.1.6+1
   flutter:
     sdk: flutter
-  daily_flutter: ^0.16.0-beta.1
+  daily_flutter: ^0.28.1
   http: ^1.2.0
   json_annotation: ^4.8.1
   web_socket_channel: ^2.4.0
   provider: ^6.1.1
   flutter_bloc: ^8.1.4
-  permission_handler: ^10.4.5
+  permission_handler: ^11.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#### **Changes**  
✅ Upgraded **daily_flutter** and **permission_handler** to their latest versions. Since **daily_flutter** has been updated, **permission_handler** was also bumped accordingly. This resolves existing Android build issues.

Could possibly be a fix of [#13](https://github.com/VapiAI/client-sdk-flutter/pull/14#issue-2884160264) and [#15](https://github.com/VapiAI/client-sdk-flutter/issues/15)