### PR TITLE
chore: generate new release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-01-27
+
+### Fixed
+
+- Fixed null cast issue when using inline assistant configuration
+- Made `assistantId` nullable in interface and implementations
+
+### Platform Support
+
+- Updated iOS deployment target requirement to 13.0+ in README
+- Updated Android minimum SDK requirement to 24 in README
+
 ## [0.1.0] - 2024-02-12
 
 ### Added

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vapi
 description: "The Vapi Flutter Client SDK with unified mobile and web support."
-version: 0.1.0
+version: 0.1.1
 homepage: https://vapi.ai/
 
 environment:
@@ -12,17 +12,17 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  
+
   # general dependencies
   http: ^1.2.0
 
-  
+
   # Mobile-specific dependencies
   daily_flutter: ^0.31.0
   # Note: permission_handler is constrained by daily_flutter 0.31.0
   # which requires ^11.3.1. Update when daily_flutter supports ^12.0.0
   permission_handler: ^11.3.1
-  
+
   # Web-specific dependencies
   web: ^1.1.0
 


### PR DESCRIPTION
- Generate new release with changelog:

### Fixed

- Fixed null cast issue when using inline assistant configuration
- Made `assistantId` nullable in interface and implementations

### Platform Support

- Updated iOS deployment target requirement to 13.0+ in README
- Updated Android minimum SDK requirement to 24 in README